### PR TITLE
Activate tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+language: python
+
+python:
+    - 2.6
+    - 2.7
+    - 3.2
+    - 3.3
+
+env:
+    # try all python versions with the latest stable numpy and astropy
+    - ASTROPY_VERSION=stable NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+
+matrix:
+    include:
+        - python: 2.7
+          # opdeps needed because the matplotlib sphinx extension requires them
+          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='build_sphinx -w -n'
+
+        # try alternate numpy versions with the latest stable astropy
+        - python: 2.7
+          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
+        - python: 2.7
+          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.5.1 SETUP_CMD='test'
+        - python: 3.2
+          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
+        # numpy < 1.6 does not work on py 3.x
+
+        # try latest developer version of astropy
+        - python: 2.7
+          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+        - python: 3.3
+          env: ASTROPY_VERSION=development NUMPY_VERSION=1.7.1 SETUP_CMD='test'
+
+before_install:
+   # We do this to make sure we get the dependencies so pip works below
+   - sudo apt-get update -qq
+   - sudo apt-get install -qq python-numpy python-sphinx cython libatlas-dev liblapack-dev gfortran
+   - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install -qq python-sphinx graphviz texlive-latex-extra dvipng python-matplotlib; fi
+
+install:
+   - export PYTHONIOENCODING=UTF8 # just in case
+   - pip -q install --upgrade "numpy==$NUMPY_VERSION" --use-mirrors
+   - pip -q install --upgrade Cython --use-mirrors
+   - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install sphinx==1.1.3 --use-mirrors; fi
+   - if [[ $SETUP_CMD == build_sphinx* ]]; then pip -q install matplotlib --use-mirrors; fi
+
+   - if [[ $ASTROPY_VERSION == stable ]]; then pip -q install astropy --use-mirrors; fi
+   - if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+http://github.com/astropy/astropy.git#egg=astropy --use-mirrors; fi
+
+   # Build Montage from source
+   - wget http://montage.ipac.caltech.edu/download/Montage_v3.3.tar.gz
+   - tar zxf Montage_v3.3.tar.gz
+   - cd Montage_v3.3
+   - make
+   - cd ..
+   - export PATH=$PATH:$PWD/Montage_v3.3/bin
+
+script:
+   - python setup.py $SETUP_CMD


### PR DESCRIPTION
There are no builds here:
https://travis-ci.org/astropy/montage-wrapper
and thus the build status is unknown here:
https://github.com/astropy/astropy/wiki/travis-ci-test-status

Do you have to enable the build on travis-ci?
Or make a dummy commit or manually trigger a build?
