### PR TITLE
Always clean up the temporary directory used by mosaic()

### DIFF
--- a/montage_wrapper/wrappers.py
+++ b/montage_wrapper/wrappers.py
@@ -409,7 +409,7 @@ def mosaic(input_dir, output_dir, header=None, image_table=None, mpi=False,
         Whether the output mosaic should match the input header exactly, or
         whether the mosaic should be trimmed if possible.
 
-    clenup : bool, optional
+    cleanup : bool, optional
         Whether to remove any temporary directories used for mosaicking
 
     bitpix : int, optional


### PR DESCRIPTION
The high-level function `mosaic()` leaves the temporary working directory hanging around if an exception is raised or the user terminates the execution with `Ctrl-C`. We can use `atexit` to register a clean-up function that makes sure at termination that the temporary directory is deleted. Another option would have been a `try-finally` block, but that would require moving most of the function inside the `try` — nevertheless, if you feel that is more appropriate I'll be happy to update this pull request.

We can also make the name of the temporary directory, created with `mkdtemp()`, a little bit more meaningful. Instead of something like `/tmp/tmpRNKj5m`, we can include in the name the basename of the input directory, resulting in, for example, `montage_mosaic_ngc2264_RNKj5` — provided that the name of the input directory is `ngc2264`. This may be useful for debugging purposes, in order to help easily identify the working directory among other temporary files.
