### PR TITLE
Don't run 2to3 for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(name=PACKAGENAME.replace('_', '-'),
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
As mentioned in https://github.com/astropy/package-template/pull/93 it would be nice if Astropy and all affiliated packages worked with a single Python 2 / 3 codebase.

This is usually not hard to achieve ... set `use_2to3=False` in `setup.py` and then once run `2to3` on your package and manually go through the suggested changes to see which ones make sense.
