### PR TITLE
Add check for Windows-style path commands to __init__.py

### DIFF
--- a/montage_wrapper/__init__.py
+++ b/montage_wrapper/__init__.py
@@ -24,6 +24,13 @@ if not _ASTROPY_SETUP_:
             installed = True
             break
 
+    # Check for Windows installation of Montage
+    if not installed:
+        for dir in os.environ['PATH'].split(';'):
+            if os.path.exists(dir + '/mProject.exe'):
+                installed = True
+                break
+
     import textwrap
 
     error_wrap = textwrap.TextWrapper(initial_indent=" " * 11,


### PR DESCRIPTION
Resolves #32. 

The way the `__init__` file previously checked for the installation of Montage was broken on Windows. Now, if Montage is not found at first, it will attempt another way of parsing `PATH` that should work on Windows.